### PR TITLE
Set correct permissions (755) for ephermeral mountdir

### DIFF
--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -582,7 +582,7 @@ fake-base-path/data/sys/log/*.log fake-base-path/data/sys/log/.*.log fake-base-p
 
 				dataDir := fs.GetFileTestStat("/fake-dir/data")
 				Expect(dataDir.FileType).To(Equal(fakesys.FakeFileTypeDir))
-				Expect(dataDir.FileMode).To(Equal(os.FileMode(0750)))
+				Expect(dataDir.FileMode).To(Equal(os.FileMode(0755)))
 			})
 
 			It("creates new partition even if the data directory is not empty", func() {
@@ -1173,7 +1173,7 @@ fake-base-path/data/sys/log/*.log fake-base-path/data/sys/log/.*.log fake-base-p
 
 				dataDir := fs.GetFileTestStat("/fake-dir/data")
 				Expect(dataDir.FileType).To(Equal(fakesys.FakeFileTypeDir))
-				Expect(dataDir.FileMode).To(Equal(os.FileMode(0750)))
+				Expect(dataDir.FileMode).To(Equal(os.FileMode(0755)))
 
 				Expect(partitioner.PartitionCalled).To(BeFalse())
 				Expect(formatter.FormatCalled).To(BeFalse())
@@ -1512,8 +1512,10 @@ Number  Start   End     Size    File system  Name             Flags
 				Expect(sysLogStats).ToNot(BeNil())
 				Expect(sysLogStats.FileType).To(Equal(fakesys.FakeFileTypeDir))
 				Expect(sysLogStats.FileMode).To(Equal(os.FileMode(0750)))
-				Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"chown", "root:vcap", "/fake-dir/data/sys"}))
-				Expect(cmdRunner.RunCommands[1]).To(Equal([]string{"chown", "root:vcap", "/fake-dir/data/sys/log"}))
+				Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"chown", "root:root", "/fake-dir/data"}))
+				Expect(cmdRunner.RunCommands[1]).To(Equal([]string{"chmod", "755", "/fake-dir/data"}))
+				Expect(cmdRunner.RunCommands[2]).To(Equal([]string{"chown", "root:vcap", "/fake-dir/data/sys"}))
+				Expect(cmdRunner.RunCommands[3]).To(Equal([]string{"chown", "root:vcap", "/fake-dir/data/sys/log"}))
 			})
 
 			It("creates symlink from sys to data/sys", func() {
@@ -1554,8 +1556,10 @@ Number  Start   End     Size    File system  Name             Flags
 				Expect(sysLogStats).ToNot(BeNil())
 				Expect(sysLogStats.FileType).To(Equal(fakesys.FakeFileTypeDir))
 				Expect(sysLogStats.FileMode).To(Equal(os.FileMode(0750)))
-				Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"chown", "root:vcap", "/fake-dir/data/sys"}))
-				Expect(cmdRunner.RunCommands[1]).To(Equal([]string{"chown", "root:vcap", "/fake-dir/data/sys/log"}))
+				Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"chown", "root:root", "/fake-dir/data"}))
+				Expect(cmdRunner.RunCommands[1]).To(Equal([]string{"chmod", "755", "/fake-dir/data"}))
+				Expect(cmdRunner.RunCommands[2]).To(Equal([]string{"chown", "root:vcap", "/fake-dir/data/sys"}))
+				Expect(cmdRunner.RunCommands[3]).To(Equal([]string{"chown", "root:vcap", "/fake-dir/data/sys/log"}))
 			})
 
 			It("creates symlink from sys to data/sys", func() {
@@ -1576,7 +1580,7 @@ Number  Start   End     Size    File system  Name             Flags
 				Expect(sysRunStats).ToNot(BeNil())
 				Expect(sysRunStats.FileType).To(Equal(fakesys.FakeFileTypeDir))
 				Expect(sysRunStats.FileMode).To(Equal(os.FileMode(0750)))
-				Expect(cmdRunner.RunCommands[2]).To(Equal([]string{"chown", "root:vcap", "/fake-dir/data/sys/run"}))
+				Expect(cmdRunner.RunCommands[4]).To(Equal([]string{"chown", "root:vcap", "/fake-dir/data/sys/run"}))
 			})
 
 			It("mounts tmpfs to sys/run", func() {


### PR DESCRIPTION
 * Also enforce that these permissions are correct on the
   mounted file system
 * This allows the bosh-agent to start when SkipDiskSetup=true